### PR TITLE
Snap interface mining

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ apps:
       - opengl
       - home
       - removable-media
+      - network
 
 parts:
   qxmledit:


### PR DESCRIPTION
This branch is used for the investigation of the missing interface connection of the snap, not all AppArmor denials are required to be fixed, only the one that actually depended by the application should be connected.