### PR TITLE
Use new null part syntax for desktop-qt5 remote part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -231,5 +231,5 @@ parts:
       opt/qxmledit/qxmledit: bin/qxmledit
       opt/qxmledit/QXmlEdit.appdata.xml: meta/gui/QXmlEdit.appdata.xml
       opt/qxmledit/sample.style: bin/sample.style
-    after: [desktop-qt5]
       
+  desktop-qt5:


### PR DESCRIPTION
Since Snapcraft 2.43 it's now possible to specify building a part
without listing it in an existing part's after clause, which may cause
the depending part unnecessarily cleaned due to the dependency.

Refer snapcore/snapcraft#2153 for more info about the syntax.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>