### PR TITLE
Fix resource lookup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ architectures:
 apps:
   qxmledit:
     command: desktop-launch $SNAP/bin/qxmledit
-    desktop: opt/qxmledit/QXmlEdit.desktop
+    desktop: share/${SNAPCRAFT_PROJECT_NAME}/QXmlEdit.desktop
     plugs:
       - desktop
       - desktop-legacy
@@ -25,17 +25,20 @@ apps:
       - opengl
       - home
       - removable-media
-    environment:
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/opt/qxmledit/
+
 parts:
   qxmledit:
     plugin: qmake
     qt-version: qt5
     options:
       - CONFIG+=release
+      - QXMLEDIT_INST_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/bin
+      - QXMLEDIT_INST_DATA_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/share/$SNAPCRAFT_PROJECT_NAME
+      - QXMLEDIT_INST_DOC_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/share/$SNAPCRAFT_PROJECT_NAME/doc
+      - QXMLEDIT_INST_LIB_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/lib
+      - QXMLEDIT_INST_INCLUDE_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/share/$SNAPCRAFT_PROJECT_NAME/include
     source: https://github.com/lbellonda/qxmledit.git
-    source-branch: master
-    source-type: git
+    source-depth: 50
     build-packages:
       - build-essential
       - libgl1-mesa-dev
@@ -48,7 +51,7 @@ parts:
       - libqt5opengl5-dev
     override-build: |
       snapcraftctl build
-      sed -i 's|Icon=qxmledit|Icon=\${SNAP}/meta/gui/icon.svg|' ${SNAPCRAFT_PART_INSTALL}/opt/qxmledit/QXmlEdit.desktop
+      sed -i 's|Icon=qxmledit|Icon=\${SNAP}/meta/gui/icon.svg|' "${SNAPCRAFT_PART_INSTALL}"/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/share/"${SNAPCRAFT_PROJECT_NAME}"/QXmlEdit.desktop
     stage-packages:
       - libqt5svg5
       - libqt5xmlpatterns5
@@ -228,8 +231,6 @@ parts:
       - -usr/share/doc/libx11-xcb1/changelog.Debian.gz
       - -usr/share/doc/libxkbcommon0/changelog.Debian.gz
     organize:
-      opt/qxmledit/qxmledit: bin/qxmledit
-      opt/qxmledit/QXmlEdit.appdata.xml: meta/gui/QXmlEdit.appdata.xml
-      opt/qxmledit/sample.style: bin/sample.style
+      snap/$SNAPCRAFT_PROJECT_NAME/current: /
     after: [desktop-qt5]
       


### PR DESCRIPTION
The qmake project honours several variables for resource lookup[1], this commit fixes it under $SNAP to make resource lookup possible.

Fixes #2.

[1] https://github.com/lbellonda/qxmledit/blob/master/INSTALL

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>