### PR TITLE
Enable build on all possible architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,12 @@ architectures:
   - build-on: amd64
   - build-on: i386
   - build-on: arm64
+  - build-on: ppc64el
+  - build-on: s390x
+
+  # armhf Not currently buildable due to the following bug:
+  # https://github.com/KhronosGroup/OpenGL-Registry/issues/162
+  #- build-on: armhf
 apps:
   qxmledit:
     command: desktop-launch $SNAP/bin/qxmledit


### PR DESCRIPTION
It is possible to build QXmlEdit on all supported arches except armhf,
enable all of them.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>